### PR TITLE
Disable computer field without user password

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@
 - 💾 **"Remember user and domain"** option (saves ID and AD, encrypted in `%LOCALAPPDATA%\LAPS-UI\prefs.json`).
 - 🕘 **History** of retrieved computers, stored encrypted and accessible via a dedicated icon.
 - 🧠 **Autocomplete suggestions** for computer names with adaptive window sizing.
+- 🚫 **Computer name field** disabled until a **user password** is entered.
 - ⚠️ **No password storage** on disk. No AD module required.
 
 ---
@@ -114,4 +115,16 @@ If SmartScreen/EDR blocks it: use the .ps1, sign the binary, or have it approved
 
 - **Windows PowerShell 5.1**
 - Not designed for **PowerShell 7** (WPF/WinRT differs)
+
+---
+
+## 📝 Release Notes
+
+```markdown
+## Summary
+- disable computer name field until a user password is entered
+
+## Testing
+- `pwsh -NoLogo -NoProfile -File scripts/LAPS-UI.ps1`
+```
 

--- a/scripts/LAPS-UI.ps1
+++ b/scripts/LAPS-UI.ps1
@@ -575,6 +575,10 @@ function Load-Prefs {
   $script:UseLdaps = [bool]$cbLdaps.IsChecked
 }
 Load-Prefs
+$tbComp.IsEnabled = -not [string]::IsNullOrWhiteSpace($pbPass.Password)
+$pbPass.Add_PasswordChanged({
+    $tbComp.IsEnabled = -not [string]::IsNullOrWhiteSpace($pbPass.Password)
+})
 $cbRememberUser.Add_Checked({ Save-Prefs })
 $cbRememberUser.Add_Unchecked({ Save-Prefs })
 $tbUser.Add_LostFocus({ if ($cbRememberUser.IsChecked) { Save-Prefs } })


### PR DESCRIPTION
## Summary
- disable computer name field until a user password is entered
- document the feature and add a release notes template in the README

## Testing
- `pwsh -NoLogo -NoProfile -File scripts/LAPS-UI.ps1` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c03c0ed5b48320bc32b7766b7e1f14