### PR TITLE
feat: add settings page

### DIFF
--- a/scripts/LAPS-UI.ps1
+++ b/scripts/LAPS-UI.ps1
@@ -6,7 +6,7 @@
 
 # --- Config ---
 $UseLdaps = $false
-$ClipboardAutoClearSeconds = 20
+$script:ClipboardAutoClearSeconds = 20
 $CurrentVersion = '1.0.5'
 
 Add-Type -AssemblyName PresentationFramework, PresentationCore, WindowsBase
@@ -351,14 +351,16 @@ Start-Process -FilePath $Exe
     </Style>
   </Window.Resources>
 
-  <Grid Margin="16">
-      <Grid.RowDefinitions>
-        <RowDefinition Height="Auto"/>
-        <RowDefinition Height="Auto"/>
-        <RowDefinition Height="Auto"/>
-        <RowDefinition Height="Auto"/>
-        <RowDefinition Height="Auto"/>
-      </Grid.RowDefinitions>
+  <TabControl Margin="16">
+    <TabItem Header="Main">
+      <Grid>
+        <Grid.RowDefinitions>
+          <RowDefinition Height="Auto"/>
+          <RowDefinition Height="Auto"/>
+          <RowDefinition Height="Auto"/>
+          <RowDefinition Height="Auto"/>
+          <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
 
       <!-- Credentials & AD target side by side -->
       <Grid Grid.Row="0" Margin="0,0,0,14">
@@ -373,28 +375,25 @@ Start-Process -FilePath $Exe
               <ColumnDefinition Width="Auto"/><ColumnDefinition Width="*"/>
             </Grid.ColumnDefinitions>
             <Grid.RowDefinitions>
-              <RowDefinition Height="Auto"/><RowDefinition Height="Auto"/><RowDefinition Height="Auto"/>
+              <RowDefinition Height="Auto"/><RowDefinition Height="Auto"/>
             </Grid.RowDefinitions>
             <TextBlock Grid.Row="0" Grid.Column="0" Text="User (user@domain)" Margin="0,0,12,0" VerticalAlignment="Center" Foreground="#BEBEBE"/>
             <TextBox   Grid.Row="0" Grid.Column="1" x:Name="tbUser"/>
             <TextBlock Grid.Row="1" Grid.Column="0" Text="Password" Margin="0,8,12,0" VerticalAlignment="Center" Foreground="#BEBEBE"/>
             <PasswordBox Grid.Row="1" Grid.Column="1" x:Name="pbPass" Margin="0,8,0,0"/>
-            <CheckBox Grid.Row="2" Grid.Column="1" x:Name="cbRememberUser" Content="Remember user" Margin="0,8,0,0"/>
           </Grid>
         </GroupBox>
 
         <GroupBox Grid.Column="1" Header="Active Directory Target" Margin="8,0,0,0">
           <Grid>
             <Grid.ColumnDefinitions>
-              <ColumnDefinition Width="Auto"/><ColumnDefinition Width="*"/><ColumnDefinition Width="Auto"/>
+              <ColumnDefinition Width="Auto"/><ColumnDefinition Width="*"/>
             </Grid.ColumnDefinitions>
             <Grid.RowDefinitions>
-              <RowDefinition Height="Auto"/><RowDefinition Height="Auto"/>
+              <RowDefinition Height="Auto"/>
             </Grid.RowDefinitions>
             <TextBlock Grid.Row="0" Grid.Column="0" VerticalAlignment="Center" Text="Controller/Domain" Margin="0,0,12,0" Foreground="#BEBEBE"/>
             <TextBox   Grid.Row="0" Grid.Column="1" x:Name="tbServer" Text=""/>
-            <CheckBox  Grid.Row="0" Grid.Column="2" x:Name="cbLdaps" Content="Use LDAPS (TLS 636)" Margin="12,0,0,0" VerticalAlignment="Center"/>
-            <CheckBox  Grid.Row="1" Grid.Column="1" Grid.ColumnSpan="2" x:Name="cbRememberServer" Content="Remember controller/domain" Margin="0,8,0,0"/>
           </Grid>
         </GroupBox>
       </Grid>
@@ -443,7 +442,7 @@ Start-Process -FilePath $Exe
             <ColumnDefinition Width="*"/><ColumnDefinition Width="Auto"/><ColumnDefinition Width="Auto"/>
           </Grid.ColumnDefinitions>
           <Grid.RowDefinitions>
-            <RowDefinition Height="Auto"/><RowDefinition Height="Auto"/><RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/><RowDefinition Height="Auto"/>
           </Grid.RowDefinitions>
 
           <!-- NEW: RichTextBox for colorized clear text -->
@@ -455,12 +454,7 @@ Start-Process -FilePath $Exe
           <CheckBox Grid.Row="0" Grid.Column="1" x:Name="cbShow" Content="Show" Margin="12,6,12,0" VerticalAlignment="Center"/>
           <Button   Grid.Row="0" Grid.Column="2" x:Name="btnCopy" Content="Copy" Style="{StaticResource AccentButton}" IsEnabled="False"/>
 
-          <StackPanel Grid.Row="1" Grid.Column="0" Orientation="Horizontal" Margin="0,8,0,0">
-            <TextBlock Text="Clipboard delay (s)" Margin="0,0,8,0" VerticalAlignment="Center" Foreground="#BEBEBE"/>
-            <TextBox x:Name="tbClipboardSecs" Width="50"/>
-          </StackPanel>
-
-          <TextBlock Grid.Row="2" Grid.Column="0" x:Name="lblCountdown" Margin="0,8,0,0" Foreground="#FFA07A" Visibility="Collapsed"/>
+          <TextBlock Grid.Row="1" Grid.Column="0" x:Name="lblCountdown" Margin="0,8,0,0" Foreground="#FFA07A" Visibility="Collapsed"/>
         </Grid>
       </GroupBox>
 
@@ -469,6 +463,48 @@ Start-Process -FilePath $Exe
         <Button x:Name="btnIgnore" Content="Ignore" Style="{StaticResource AccentButton}" Margin="8,0,0,0" Visibility="Collapsed"/>
       </StackPanel>
     </Grid>
+  </TabItem>
+  <TabItem Header="Settings">
+    <StackPanel Margin="10">
+      <GroupBox Header="Security">
+        <StackPanel>
+          <CheckBox x:Name="cbLdaps" Content="Use LDAPS (TLS 636)" Margin="0,0,0,8"/>
+          <CheckBox x:Name="cbClipboardAutoClear" Content="Enable clipboard auto-clear" IsChecked="True" Margin="0,0,0,8"/>
+          <StackPanel Orientation="Horizontal" Margin="20,0,0,0">
+            <TextBlock Text="Clipboard delay (s)" Margin="0,0,8,0" VerticalAlignment="Center" Foreground="#BEBEBE"/>
+            <TextBox x:Name="tbClipboardSecs" Width="50"/>
+          </StackPanel>
+        </StackPanel>
+      </GroupBox>
+      <GroupBox Header="Preferences">
+        <StackPanel>
+          <CheckBox x:Name="cbRememberUser" Content="Remember user"/>
+          <CheckBox x:Name="cbRememberServer" Content="Remember controller/domain"/>
+          <CheckBox x:Name="cbAutoUpdate" Content="Check for updates on launch" IsChecked="True"/>
+          <CheckBox x:Name="cbConfirmCopy" Content="Confirm before copying"/>
+        </StackPanel>
+      </GroupBox>
+      <GroupBox Header="Appearance">
+        <StackPanel>
+          <StackPanel Orientation="Horizontal" Margin="0,0,0,8">
+            <TextBlock Text="Theme" Margin="0,0,8,0" VerticalAlignment="Center" Foreground="#BEBEBE"/>
+            <ComboBox x:Name="cmbTheme" Width="120">
+              <ComboBoxItem Content="Dark"/>
+              <ComboBoxItem Content="Light"/>
+            </ComboBox>
+          </StackPanel>
+          <StackPanel Orientation="Horizontal">
+            <TextBlock Text="Language" Margin="0,0,8,0" VerticalAlignment="Center" Foreground="#BEBEBE"/>
+            <ComboBox x:Name="cmbLanguage" Width="120">
+              <ComboBoxItem Content="English"/>
+              <ComboBoxItem Content="French"/>
+            </ComboBox>
+          </StackPanel>
+        </StackPanel>
+      </GroupBox>
+    </StackPanel>
+  </TabItem>
+  </TabControl>
 </Window>
 "@ 
 
@@ -497,15 +533,20 @@ $cbShow         = $window.FindName("cbShow")
 $btnCopy        = $window.FindName("btnCopy")
 $lblCountdown   = $window.FindName("lblCountdown")
 $tbClipboardSecs = $window.FindName("tbClipboardSecs")
+$cbClipboardAutoClear = $window.FindName("cbClipboardAutoClear")
 $cbRememberUser = $window.FindName("cbRememberUser")
 $cbRememberServer = $window.FindName("cbRememberServer")
+$cbAutoUpdate   = $window.FindName("cbAutoUpdate")
+$cbConfirmCopy  = $window.FindName("cbConfirmCopy")
+$cmbTheme       = $window.FindName("cmbTheme")
+$cmbLanguage    = $window.FindName("cmbLanguage")
 $btnUpdate     = $window.FindName("btnUpdate")
 $btnIgnore     = $window.FindName("btnIgnore")
 
 # Init
 $cbLdaps.IsChecked = $UseLdaps
 $script:UseLdaps   = [bool]$cbLdaps.IsChecked
-$tbClipboardSecs.Text = $ClipboardAutoClearSeconds
+$tbClipboardSecs.Text = $script:ClipboardAutoClearSeconds
 $script:CurrentLapsPassword = ""
 $script:DoneTimer = $null
 
@@ -537,14 +578,19 @@ function Save-Prefs {
   $history = $script:Prefs.History
   $ignore  = $script:Prefs.IgnoreVersion
   $script:Prefs = @{
-    RememberUser     = [bool]$cbRememberUser.IsChecked
-    UserName         = $(if ($cbRememberUser.IsChecked)   { Protect-String $tbUser.Text } else { $null })
-    RememberServer   = [bool]$cbRememberServer.IsChecked
-    ServerName       = $(if ($cbRememberServer.IsChecked) { Protect-String $tbServer.Text } else { $null })
-    UseLdaps         = [bool]$cbLdaps.IsChecked
-    ClipboardSeconds = $script:ClipboardAutoClearSeconds
-    History          = $history
-    IgnoreVersion    = $ignore
+    RememberUser        = [bool]$cbRememberUser.IsChecked
+    UserName            = $(if ($cbRememberUser.IsChecked)   { Protect-String $tbUser.Text } else { $null })
+    RememberServer      = [bool]$cbRememberServer.IsChecked
+    ServerName          = $(if ($cbRememberServer.IsChecked) { Protect-String $tbServer.Text } else { $null })
+    UseLdaps            = [bool]$cbLdaps.IsChecked
+    AutoClearClipboard  = [bool]$cbClipboardAutoClear.IsChecked
+    ClipboardSeconds    = $script:ClipboardAutoClearSeconds
+    AutoUpdate          = [bool]$cbAutoUpdate.IsChecked
+    ConfirmCopy         = [bool]$cbConfirmCopy.IsChecked
+    Theme               = $cmbTheme.Text
+    Language            = $cmbLanguage.Text
+    History             = $history
+    IgnoreVersion       = $ignore
   }
   $persist = $script:Prefs.Clone()
   $persist.History = @($history | ForEach-Object { Protect-String $_ })
@@ -557,8 +603,13 @@ function Load-Prefs {
       $loaded = Get-Content $PrefFile -Raw | ConvertFrom-Json
       if ($loaded.RememberUser) { $cbRememberUser.IsChecked = $true; if ($loaded.UserName) { $tbUser.Text = Unprotect-String $loaded.UserName } }
       if ($loaded.RememberServer) { $cbRememberServer.IsChecked = $true; if ($loaded.ServerName) { $tbServer.Text = Unprotect-String $loaded.ServerName } }
-      if ($loaded.UseLdaps) { $cbLdaps.IsChecked = [bool]$loaded.UseLdaps }
+      if ($null -ne $loaded.UseLdaps) { $cbLdaps.IsChecked = [bool]$loaded.UseLdaps }
+      if ($null -ne $loaded.AutoClearClipboard) { $cbClipboardAutoClear.IsChecked = [bool]$loaded.AutoClearClipboard }
       if ($loaded.ClipboardSeconds) { $script:ClipboardAutoClearSeconds = [int]$loaded.ClipboardSeconds }
+      if ($null -ne $loaded.AutoUpdate) { $cbAutoUpdate.IsChecked = [bool]$loaded.AutoUpdate }
+      if ($null -ne $loaded.ConfirmCopy) { $cbConfirmCopy.IsChecked = [bool]$loaded.ConfirmCopy }
+      if ($loaded.Theme) { $cmbTheme.Text = $loaded.Theme }
+      if ($loaded.Language) { $cmbLanguage.Text = $loaded.Language }
       $hist = @()
       if ($loaded.History -is [System.Collections.IEnumerable]) {
         foreach ($enc in $loaded.History) {
@@ -590,6 +641,14 @@ $window.Add_Closed({ Save-Prefs })
 $cbLdaps.Add_Checked({   $script:UseLdaps = $true;  Save-Prefs })
 $cbLdaps.Add_Unchecked({ $script:UseLdaps = $false; Save-Prefs })
 $tbClipboardSecs.Add_LostFocus({ Save-Prefs })
+$cbClipboardAutoClear.Add_Checked({ Save-Prefs })
+$cbClipboardAutoClear.Add_Unchecked({ Save-Prefs })
+$cbAutoUpdate.Add_Checked({ Save-Prefs })
+$cbAutoUpdate.Add_Unchecked({ Save-Prefs })
+$cbConfirmCopy.Add_Checked({ Save-Prefs })
+$cbConfirmCopy.Add_Unchecked({ Save-Prefs })
+$cmbTheme.Add_SelectionChanged({ Save-Prefs })
+$cmbLanguage.Add_SelectionChanged({ Save-Prefs })
 $tbComp.Add_TextChanged({
     Update-ComputerSuggestions $tbComp.Text
     if ($gbDetails.Visibility -ne 'Collapsed') {
@@ -714,6 +773,10 @@ $timer.Add_Tick({
 
 $btnCopy.Add_Click({
   if ([string]::IsNullOrWhiteSpace($script:CurrentLapsPassword)) { return }
+  if ($cbConfirmCopy.IsChecked) {
+    $res = [System.Windows.MessageBox]::Show("Copy password to clipboard?","Confirm",'YesNo','Question')
+    if ($res -ne 'Yes') { return }
+  }
   $usedWinRT = $false
   try {
     $winRtSupported = [Windows.Foundation.Metadata.ApiInformation]::IsMethodPresent(
@@ -734,15 +797,22 @@ $btnCopy.Add_Click({
   [System.Windows.MessageBox]::Show(("Password copied {0} clipboard history." -f ($(if($usedWinRT){'without entering'}else{'into'}))),
     "Copied",'OK','Information') | Out-Null
 
-  $script:CountdownRemaining = $ClipboardAutoClearSeconds
-  $lblCountdown.Text = "Clipboard cleared in $($script:CountdownRemaining)s"
-  $lblCountdown.Foreground = '#FFA07A'
-  $lblCountdown.Visibility = 'Visible'
-  $timer.Stop(); $timer.Start()
+  if ($cbClipboardAutoClear.IsChecked) {
+    $script:CountdownRemaining = $script:ClipboardAutoClearSeconds
+    $lblCountdown.Text = "Clipboard cleared in $($script:CountdownRemaining)s"
+    $lblCountdown.Foreground = '#FFA07A'
+    $lblCountdown.Visibility = 'Visible'
+    $timer.Stop(); $timer.Start()
+  } else {
+    $lblCountdown.Visibility = 'Collapsed'
+  }
 })
 
 # ---------- Retrieve ----------
-$updateInfo = Check-ForUpdates -CurrentVersion $CurrentVersion
+$updateInfo = $null
+if ($cbAutoUpdate.IsChecked) {
+  $updateInfo = Check-ForUpdates -CurrentVersion $CurrentVersion
+}
 if ($updateInfo) {
   $btnUpdate.Content = "Update to v$($updateInfo.Version)"
   $btnUpdate.Visibility = 'Visible'

--- a/scripts/LAPS-UI.ps1
+++ b/scripts/LAPS-UI.ps1
@@ -351,9 +351,9 @@ Start-Process -FilePath $Exe
     </Style>
   </Window.Resources>
 
-  <TabControl Margin="16">
+  <TabControl Margin="16" Background="#1E1E1E" BorderThickness="0">
     <TabItem Header="Main">
-      <Grid>
+      <Grid Background="#1E1E1E">
         <Grid.RowDefinitions>
           <RowDefinition Height="Auto"/>
           <RowDefinition Height="Auto"/>
@@ -465,7 +465,7 @@ Start-Process -FilePath $Exe
     </Grid>
   </TabItem>
   <TabItem Header="Settings">
-    <StackPanel Margin="10">
+    <StackPanel Margin="10" Background="#1E1E1E">
       <GroupBox Header="Security">
         <StackPanel>
           <CheckBox x:Name="cbLdaps" Content="Use LDAPS (TLS 636)" Margin="0,0,0,8"/>

--- a/scripts/LAPS-UI.ps1
+++ b/scripts/LAPS-UI.ps1
@@ -238,7 +238,7 @@ Start-Process -FilePath $Exe
         Title="LAPS UI (Windows &amp; Legacy) - v$CurrentVersion"
         Width="1000" MinWidth="1000" SizeToContent="Height"
         WindowStartupLocation="CenterScreen"
-        Background="#000000" Foreground="#EEEEEE" FontFamily="Segoe UI" FontSize="13">
+        Background="#1E1E1E" Foreground="#EEEEEE" FontFamily="Segoe UI" FontSize="13">
   <Window.Resources>
     <SolidColorBrush x:Key="LabelBrush" Color="#BEBEBE"/>
     <Style x:Key="AccentButton" TargetType="Button">
@@ -553,7 +553,7 @@ $lightThemeXaml = @"
 
   <Style TargetType="TextBox">
     <Setter Property="Background" Value="#FFFFFF"/>
-    <Setter Property="Foreground" Value="#000000"/>
+    <Setter Property="Foreground" Value="#1E1E1E"/>
     <Setter Property="BorderBrush" Value="#CCCCCC"/>
     <Setter Property="BorderThickness" Value="1"/>
     <Setter Property="Padding" Value="8,6"/>
@@ -571,7 +571,7 @@ $lightThemeXaml = @"
 
   <Style TargetType="RichTextBox">
     <Setter Property="Background" Value="#FFFFFF"/>
-    <Setter Property="Foreground" Value="#000000"/>
+    <Setter Property="Foreground" Value="#1E1E1E"/>
     <Setter Property="BorderBrush" Value="#CCCCCC"/>
     <Setter Property="BorderThickness" Value="1"/>
     <Setter Property="Padding" Value="4"/>
@@ -582,7 +582,7 @@ $lightThemeXaml = @"
 
   <Style TargetType="PasswordBox">
     <Setter Property="Background" Value="#FFFFFF"/>
-    <Setter Property="Foreground" Value="#000000"/>
+    <Setter Property="Foreground" Value="#1E1E1E"/>
     <Setter Property="BorderBrush" Value="#CCCCCC"/>
     <Setter Property="BorderThickness" Value="1"/>
     <Setter Property="Padding" Value="8,6"/>
@@ -599,7 +599,7 @@ $lightThemeXaml = @"
   </Style>
 
   <Style TargetType="GroupBox">
-    <Setter Property="Foreground" Value="#000000"/>
+    <Setter Property="Foreground" Value="#1E1E1E"/>
     <Setter Property="BorderBrush" Value="#CCCCCC"/>
     <Setter Property="BorderThickness" Value="1"/>
     <Setter Property="Padding" Value="12"/>
@@ -622,7 +622,7 @@ $lightThemeXaml = @"
   </Style>
 
   <Style TargetType="CheckBox">
-    <Setter Property="Foreground" Value="#000000"/>
+    <Setter Property="Foreground" Value="#1E1E1E"/>
     <Setter Property="Margin" Value="0,4,0,0"/>
   </Style>
 </ResourceDictionary>


### PR DESCRIPTION
## Summary
- split UI into main and settings pages
- add configurable options (LDAPS default, clipboard auto-clear, update check, theme/language)
- persist new preferences and hook copy logic to confirmation & auto-clear toggle

## Testing
- `pwsh -NoLogo -File scripts/LAPS-UI.ps1` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c168c4ac4c8320af3a77e4e5517320