### PR TITLE
fix: correct theme toggling and dark background

### DIFF
--- a/scripts/LAPS-UI.ps1
+++ b/scripts/LAPS-UI.ps1
@@ -352,9 +352,9 @@ Start-Process -FilePath $Exe
     </Style>
   </Window.Resources>
 
-  <TabControl Margin="16" Background="#1E1E1E" BorderThickness="0">
+  <TabControl Margin="16" Background="{Binding RelativeSource={RelativeSource AncestorType=Window}, Path=Background}" BorderThickness="0">
     <TabItem Header="Main">
-      <Grid Background="#1E1E1E">
+      <Grid Background="{Binding RelativeSource={RelativeSource AncestorType=Window}, Path=Background}">
         <Grid.RowDefinitions>
           <RowDefinition Height="Auto"/>
           <RowDefinition Height="Auto"/>
@@ -466,7 +466,7 @@ Start-Process -FilePath $Exe
     </Grid>
   </TabItem>
   <TabItem Header="Settings">
-    <StackPanel Margin="10" Background="#1E1E1E">
+    <StackPanel Margin="10" Background="{Binding RelativeSource={RelativeSource AncestorType=Window}, Path=Background}">
       <GroupBox Header="Security">
         <StackPanel>
           <CheckBox x:Name="cbLdaps" Content="Use LDAPS (TLS 636)" Margin="0,0,0,8"/>
@@ -638,7 +638,7 @@ function Apply-Theme {
     $window.Foreground = [Windows.Media.Brushes]::Black
   } else {
     $window.Resources = $script:DarkResources
-    $window.Background = [Windows.Media.Brushes]::Black
+    $window.Background = New-Object Windows.Media.SolidColorBrush ([Windows.Media.ColorConverter]::ConvertFromString('#1E1E1E'))
     $window.Foreground = [Windows.Media.Brushes]::White
   }
 }
@@ -718,7 +718,7 @@ function Save-Prefs {
     ClipboardSeconds    = $script:ClipboardAutoClearSeconds
     AutoUpdate          = [bool]$cbAutoUpdate.IsChecked
     ConfirmCopy         = [bool]$cbConfirmCopy.IsChecked
-    Theme               = $cmbTheme.Text
+    Theme               = $cmbTheme.SelectedItem.Content
     Language            = $cmbLanguage.Text
     History             = $history
     IgnoreVersion       = $ignore
@@ -739,7 +739,7 @@ function Load-Prefs {
       if ($loaded.ClipboardSeconds) { $script:ClipboardAutoClearSeconds = [int]$loaded.ClipboardSeconds }
       if ($null -ne $loaded.AutoUpdate) { $cbAutoUpdate.IsChecked = [bool]$loaded.AutoUpdate }
       if ($null -ne $loaded.ConfirmCopy) { $cbConfirmCopy.IsChecked = [bool]$loaded.ConfirmCopy }
-      if ($loaded.Theme) { $cmbTheme.Text = $loaded.Theme }
+      if ($loaded.Theme) { $cmbTheme.SelectedItem = $cmbTheme.Items | Where-Object { $_.Content -eq $loaded.Theme } }
       if ($loaded.Language) { $cmbLanguage.Text = $loaded.Language }
       $hist = @()
       if ($loaded.History -is [System.Collections.IEnumerable]) {
@@ -757,7 +757,7 @@ function Load-Prefs {
   $script:UseLdaps = [bool]$cbLdaps.IsChecked
 }
 Load-Prefs
-Apply-Theme $cmbTheme.Text
+Apply-Theme $cmbTheme.SelectedItem.Content
 $tbComp.IsEnabled = -not [string]::IsNullOrWhiteSpace($pbPass.Password)
 $pbPass.Add_PasswordChanged({
     $tbComp.IsEnabled = -not [string]::IsNullOrWhiteSpace($pbPass.Password)
@@ -779,7 +779,7 @@ $cbAutoUpdate.Add_Checked({ Save-Prefs })
 $cbAutoUpdate.Add_Unchecked({ Save-Prefs })
 $cbConfirmCopy.Add_Checked({ Save-Prefs })
 $cbConfirmCopy.Add_Unchecked({ Save-Prefs })
-$cmbTheme.Add_SelectionChanged({ Apply-Theme $cmbTheme.Text; Save-Prefs })
+$cmbTheme.Add_SelectionChanged({ Apply-Theme $cmbTheme.SelectedItem.Content; Save-Prefs })
 $cmbLanguage.Add_SelectionChanged({ Save-Prefs })
 $tbComp.Add_TextChanged({
     Update-ComputerSuggestions $tbComp.Text

--- a/scripts/LAPS-UI.ps1
+++ b/scripts/LAPS-UI.ps1
@@ -365,28 +365,27 @@ Start-Process -FilePath $Exe
       <Setter Property="FontWeight" Value="SemiBold"/>
       <Setter Property="Padding" Value="12,6"/>
       <Setter Property="Margin" Value="0,0,4,0"/>
-      <Setter Property="Background" Value="#2D2D2D"/>
       <Setter Property="Foreground" Value="#EEEEEE"/>
       <Setter Property="BorderThickness" Value="0"/>
       <Setter Property="Cursor" Value="Hand"/>
       <Setter Property="Template">
         <Setter.Value>
           <ControlTemplate TargetType="TabItem">
-            <Border Background="{TemplateBinding Background}" CornerRadius="4" Padding="{TemplateBinding Padding}">
+            <Border x:Name="TabBorder" Background="#2D2D2D" CornerRadius="4" Padding="{TemplateBinding Padding}">
               <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center"/>
             </Border>
+            <ControlTemplate.Triggers>
+              <Trigger Property="IsSelected" Value="True">
+                <Setter TargetName="TabBorder" Property="Background" Value="#0A84FF"/>
+                <Setter Property="Foreground" Value="White"/>
+              </Trigger>
+              <Trigger Property="IsMouseOver" Value="True">
+                <Setter TargetName="TabBorder" Property="Background" Value="#3E3E42"/>
+              </Trigger>
+            </ControlTemplate.Triggers>
           </ControlTemplate>
         </Setter.Value>
       </Setter>
-      <Style.Triggers>
-        <Trigger Property="IsSelected" Value="True">
-          <Setter Property="Background" Value="#0A84FF"/>
-          <Setter Property="Foreground" Value="White"/>
-        </Trigger>
-        <Trigger Property="IsMouseOver" Value="True">
-          <Setter Property="Background" Value="#3E3E42"/>
-        </Trigger>
-      </Style.Triggers>
     </Style>
   </Window.Resources>
 
@@ -668,28 +667,27 @@ $lightThemeXaml = @"
     <Setter Property="FontWeight" Value="SemiBold"/>
     <Setter Property="Padding" Value="12,6"/>
     <Setter Property="Margin" Value="0,0,4,0"/>
-    <Setter Property="Background" Value="#E5E5E5"/>
     <Setter Property="Foreground" Value="#1E1E1E"/>
     <Setter Property="BorderThickness" Value="0"/>
     <Setter Property="Cursor" Value="Hand"/>
     <Setter Property="Template">
       <Setter.Value>
         <ControlTemplate TargetType="TabItem">
-          <Border Background="{TemplateBinding Background}" CornerRadius="4" Padding="{TemplateBinding Padding}">
+          <Border x:Name="TabBorder" Background="#E5E5E5" CornerRadius="4" Padding="{TemplateBinding Padding}">
             <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center"/>
           </Border>
+          <ControlTemplate.Triggers>
+            <Trigger Property="IsSelected" Value="True">
+              <Setter TargetName="TabBorder" Property="Background" Value="#0A84FF"/>
+              <Setter Property="Foreground" Value="White"/>
+            </Trigger>
+            <Trigger Property="IsMouseOver" Value="True">
+              <Setter TargetName="TabBorder" Property="Background" Value="#DDDDDD"/>
+            </Trigger>
+          </ControlTemplate.Triggers>
         </ControlTemplate>
       </Setter.Value>
     </Setter>
-    <Style.Triggers>
-      <Trigger Property="IsSelected" Value="True">
-        <Setter Property="Background" Value="#0A84FF"/>
-        <Setter Property="Foreground" Value="White"/>
-      </Trigger>
-      <Trigger Property="IsMouseOver" Value="True">
-        <Setter Property="Background" Value="#DDDDDD"/>
-      </Trigger>
-    </Style.Triggers>
   </Style>
 </ResourceDictionary>
 "@

--- a/scripts/LAPS-UI.ps1
+++ b/scripts/LAPS-UI.ps1
@@ -360,33 +360,44 @@ Start-Process -FilePath $Exe
       <Setter Property="Margin" Value="0,4,0,0"/>
     </Style>
 
-    <Style TargetType="TabItem">
-      <Setter Property="FontSize" Value="14"/>
-      <Setter Property="FontWeight" Value="SemiBold"/>
-      <Setter Property="Padding" Value="12,6"/>
-      <Setter Property="Margin" Value="0,0,4,0"/>
-      <Setter Property="Foreground" Value="#EEEEEE"/>
-      <Setter Property="BorderThickness" Value="0"/>
-      <Setter Property="Cursor" Value="Hand"/>
-      <Setter Property="Template">
-        <Setter.Value>
-          <ControlTemplate TargetType="TabItem">
-            <Border x:Name="TabBorder" Background="#2D2D2D" CornerRadius="4" Padding="{TemplateBinding Padding}">
-              <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center"/>
-            </Border>
-            <ControlTemplate.Triggers>
-              <Trigger Property="IsSelected" Value="True">
-                <Setter TargetName="TabBorder" Property="Background" Value="#0A84FF"/>
-                <Setter Property="Foreground" Value="White"/>
-              </Trigger>
-              <Trigger Property="IsMouseOver" Value="True">
-                <Setter TargetName="TabBorder" Property="Background" Value="#3E3E42"/>
-              </Trigger>
-            </ControlTemplate.Triggers>
-          </ControlTemplate>
-        </Setter.Value>
-      </Setter>
-    </Style>
+<Style TargetType="TabControl">
+  <Setter Property="Background" Value="{Binding RelativeSource={RelativeSource AncestorType=Window}, Path=Background}"/>
+  <Setter Property="BorderThickness" Value="0"/>
+  <Setter Property="Template">
+    <Setter.Value>
+      <ControlTemplate TargetType="TabControl">
+        <Grid SnapsToDevicePixels="True">
+          <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+          </Grid.RowDefinitions>
+
+          <!-- Barre d'onglets -->
+          <TabPanel x:Name="HeaderPanel"
+                    IsItemsHost="True"
+                    Margin="12,12,12,0"
+                    KeyboardNavigation.TabIndex="1"
+                    Panel.ZIndex="1"
+                    Background="{TemplateBinding Background}"/>
+
+          <!-- Zone de contenu -->
+          <Border Grid.Row="1"
+                  Margin="12"
+                  Background="{Binding RelativeSource={RelativeSource AncestorType=Window}, Path=Background}"
+                  CornerRadius="10"
+                  BorderBrush="#3E3E42"
+                  BorderThickness="1"
+                  Padding="12">
+            <ContentPresenter x:Name="PART_SelectedContentHost"
+                              Margin="0"
+                              ContentSource="SelectedContent"
+                              SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
+          </Border>
+        </Grid>
+      </ControlTemplate>
+    </Setter.Value>
+  </Setter>
+</Style>
   </Window.Resources>
 
   <TabControl Margin="16" Background="{Binding RelativeSource={RelativeSource AncestorType=Window}, Path=Background}" BorderThickness="0">
@@ -662,33 +673,51 @@ $lightThemeXaml = @"
     <Setter Property="Foreground" Value="#1E1E1E"/>
     <Setter Property="Margin" Value="0,4,0,0"/>
   </Style>
-  <Style TargetType="TabItem">
-    <Setter Property="FontSize" Value="14"/>
-    <Setter Property="FontWeight" Value="SemiBold"/>
-    <Setter Property="Padding" Value="12,6"/>
-    <Setter Property="Margin" Value="0,0,4,0"/>
-    <Setter Property="Foreground" Value="#1E1E1E"/>
-    <Setter Property="BorderThickness" Value="0"/>
-    <Setter Property="Cursor" Value="Hand"/>
-    <Setter Property="Template">
-      <Setter.Value>
-        <ControlTemplate TargetType="TabItem">
-          <Border x:Name="TabBorder" Background="#E5E5E5" CornerRadius="4" Padding="{TemplateBinding Padding}">
-            <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center"/>
-          </Border>
-          <ControlTemplate.Triggers>
-            <Trigger Property="IsSelected" Value="True">
-              <Setter TargetName="TabBorder" Property="Background" Value="#0A84FF"/>
-              <Setter Property="Foreground" Value="White"/>
-            </Trigger>
-            <Trigger Property="IsMouseOver" Value="True">
-              <Setter TargetName="TabBorder" Property="Background" Value="#DDDDDD"/>
-            </Trigger>
-          </ControlTemplate.Triggers>
-        </ControlTemplate>
-      </Setter.Value>
-    </Setter>
-  </Style>
+<Style TargetType="TabItem">
+  <Setter Property="Foreground" Value="#EEEEEE"/>
+  <Setter Property="Padding" Value="14,8"/>
+  <Setter Property="Margin" Value="0,0,8,0"/>
+  <Setter Property="Cursor" Value="Hand"/>
+  <Setter Property="FocusVisualStyle" Value="{x:Null}"/>
+  <Setter Property="Template">
+    <Setter.Value>
+      <ControlTemplate TargetType="TabItem">
+        <Border x:Name="Bd"
+                Background="#2D2D2D"
+                CornerRadius="8"
+                Padding="{TemplateBinding Padding}"
+                SnapsToDevicePixels="True">
+          <!-- IMPORTANT : on rend seulement le Header -->
+          <ContentPresenter ContentSource="Header"
+                            HorizontalAlignment="Center"
+                            VerticalAlignment="Center"/>
+        </Border>
+        <ControlTemplate.Triggers>
+          <!-- Hover -->
+          <Trigger Property="IsMouseOver" Value="True">
+            <Setter TargetName="Bd" Property="Background" Value="#3E3E42"/>
+          </Trigger>
+
+          <!-- Désactivé -->
+          <Trigger Property="IsEnabled" Value="False">
+            <Setter Property="Opacity" Value="0.5"/>
+          </Trigger>
+
+          <!-- Sélectionné (PLACÉ APRÈS pour prendre le dessus sur le hover) -->
+          <Trigger Property="IsSelected" Value="True">
+            <Setter Property="Foreground" Value="White"/>
+            <Setter TargetName="Bd" Property="Background" Value="#0A84FF"/>
+            <Setter TargetName="Bd" Property="Effect">
+              <Setter.Value>
+                <DropShadowEffect BlurRadius="10" ShadowDepth="0" Opacity="0.35"/>
+              </Setter.Value>
+            </Setter>
+          </Trigger>
+        </ControlTemplate.Triggers>
+      </ControlTemplate>
+    </Setter.Value>
+  </Setter>
+</Style>
 </ResourceDictionary>
 "@
 $lightReader = New-Object System.Xml.XmlNodeReader ([xml]$lightThemeXaml)


### PR DESCRIPTION
## Summary
- ensure settings tab and main views respond to theme changes
- fix theme storage logic to avoid dark/light inversion
- use #1E1E1E for dark theme background

## Testing
- `pwsh -NoProfile -Command "[System.Management.Automation.Language.Parser]::ParseFile('scripts/LAPS-UI.ps1',[ref]$null,[ref]$null)"` *(failed: command not found)*
- `apt-get update` *(failed: repository 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c170b1636c8320801d873fb2984b0e