### PR TITLE
Fix tab clipping and styling in light and dark themes

### DIFF
--- a/scripts/LAPS-UI.ps1
+++ b/scripts/LAPS-UI.ps1
@@ -360,6 +360,46 @@ Start-Process -FilePath $Exe
       <Setter Property="Margin" Value="0,4,0,0"/>
     </Style>
 
+    <Style TargetType="TabItem">
+      <Setter Property="Foreground" Value="#EEEEEE"/>
+      <Setter Property="Padding" Value="14,8"/>
+      <Setter Property="Margin" Value="0,0,8,0"/>
+      <Setter Property="Cursor" Value="Hand"/>
+      <Setter Property="FocusVisualStyle" Value="{x:Null}"/>
+      <Setter Property="Template">
+        <Setter.Value>
+          <ControlTemplate TargetType="TabItem">
+            <Border x:Name="Bd"
+                    Background="#2D2D2D"
+                    CornerRadius="8"
+                    Padding="{TemplateBinding Padding}"
+                    SnapsToDevicePixels="True">
+              <ContentPresenter ContentSource="Header"
+                                HorizontalAlignment="Center"
+                                VerticalAlignment="Center"/>
+            </Border>
+            <ControlTemplate.Triggers>
+              <Trigger Property="IsMouseOver" Value="True">
+                <Setter TargetName="Bd" Property="Background" Value="#3E3E42"/>
+              </Trigger>
+              <Trigger Property="IsEnabled" Value="False">
+                <Setter Property="Opacity" Value="0.5"/>
+              </Trigger>
+              <Trigger Property="IsSelected" Value="True">
+                <Setter Property="Foreground" Value="White"/>
+                <Setter TargetName="Bd" Property="Background" Value="#0A84FF"/>
+                <Setter TargetName="Bd" Property="Effect">
+                  <Setter.Value>
+                    <DropShadowEffect BlurRadius="10" ShadowDepth="0" Opacity="0.35"/>
+                  </Setter.Value>
+                </Setter>
+              </Trigger>
+            </ControlTemplate.Triggers>
+          </ControlTemplate>
+        </Setter.Value>
+      </Setter>
+    </Style>
+
 <Style TargetType="TabControl">
   <Setter Property="Background" Value="{Binding RelativeSource={RelativeSource AncestorType=Window}, Path=Background}"/>
   <Setter Property="BorderThickness" Value="0"/>
@@ -375,7 +415,7 @@ Start-Process -FilePath $Exe
           <!-- Barre d'onglets -->
           <TabPanel x:Name="HeaderPanel"
                     IsItemsHost="True"
-                    Margin="12,12,12,0"
+                    Margin="12,12,20,0"
                     KeyboardNavigation.TabIndex="1"
                     Panel.ZIndex="1"
                     Background="{TemplateBinding Background}"/>
@@ -673,51 +713,85 @@ $lightThemeXaml = @"
     <Setter Property="Foreground" Value="#1E1E1E"/>
     <Setter Property="Margin" Value="0,4,0,0"/>
   </Style>
-<Style TargetType="TabItem">
-  <Setter Property="Foreground" Value="#EEEEEE"/>
-  <Setter Property="Padding" Value="14,8"/>
-  <Setter Property="Margin" Value="0,0,8,0"/>
-  <Setter Property="Cursor" Value="Hand"/>
-  <Setter Property="FocusVisualStyle" Value="{x:Null}"/>
-  <Setter Property="Template">
-    <Setter.Value>
-      <ControlTemplate TargetType="TabItem">
-        <Border x:Name="Bd"
-                Background="#2D2D2D"
-                CornerRadius="8"
-                Padding="{TemplateBinding Padding}"
-                SnapsToDevicePixels="True">
-          <!-- IMPORTANT : on rend seulement le Header -->
-          <ContentPresenter ContentSource="Header"
-                            HorizontalAlignment="Center"
-                            VerticalAlignment="Center"/>
-        </Border>
-        <ControlTemplate.Triggers>
-          <!-- Hover -->
-          <Trigger Property="IsMouseOver" Value="True">
-            <Setter TargetName="Bd" Property="Background" Value="#3E3E42"/>
-          </Trigger>
+  <Style TargetType="TabControl">
+    <Setter Property="Background" Value="{Binding RelativeSource={RelativeSource AncestorType=Window}, Path=Background}"/>
+    <Setter Property="BorderThickness" Value="0"/>
+    <Setter Property="Template">
+      <Setter.Value>
+        <ControlTemplate TargetType="TabControl">
+          <Grid SnapsToDevicePixels="True">
+            <Grid.RowDefinitions>
+              <RowDefinition Height="Auto"/>
+              <RowDefinition Height="*"/>
+            </Grid.RowDefinitions>
 
-          <!-- Désactivé -->
-          <Trigger Property="IsEnabled" Value="False">
-            <Setter Property="Opacity" Value="0.5"/>
-          </Trigger>
+            <TabPanel x:Name="HeaderPanel"
+                      IsItemsHost="True"
+                      Margin="12,12,20,0"
+                      KeyboardNavigation.TabIndex="1"
+                      Panel.ZIndex="1"
+                      Background="{TemplateBinding Background}"/>
 
-          <!-- Sélectionné (PLACÉ APRÈS pour prendre le dessus sur le hover) -->
-          <Trigger Property="IsSelected" Value="True">
-            <Setter Property="Foreground" Value="White"/>
-            <Setter TargetName="Bd" Property="Background" Value="#0A84FF"/>
-            <Setter TargetName="Bd" Property="Effect">
-              <Setter.Value>
-                <DropShadowEffect BlurRadius="10" ShadowDepth="0" Opacity="0.35"/>
-              </Setter.Value>
-            </Setter>
-          </Trigger>
-        </ControlTemplate.Triggers>
-      </ControlTemplate>
-    </Setter.Value>
-  </Setter>
-</Style>
+            <Border Grid.Row="1"
+                    Margin="12"
+                    Background="{Binding RelativeSource={RelativeSource AncestorType=Window}, Path=Background}"
+                    CornerRadius="10"
+                    BorderBrush="#CCCCCC"
+                    BorderThickness="1"
+                    Padding="12">
+              <ContentPresenter x:Name="PART_SelectedContentHost"
+                                Margin="0"
+                                ContentSource="SelectedContent"
+                                SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
+            </Border>
+          </Grid>
+        </ControlTemplate>
+      </Setter.Value>
+    </Setter>
+  </Style>
+
+  <Style TargetType="TabItem">
+    <Setter Property="Foreground" Value="#333333"/>
+    <Setter Property="Padding" Value="14,8"/>
+    <Setter Property="Margin" Value="0,0,8,0"/>
+    <Setter Property="Cursor" Value="Hand"/>
+    <Setter Property="FocusVisualStyle" Value="{x:Null}"/>
+    <Setter Property="Template">
+      <Setter.Value>
+        <ControlTemplate TargetType="TabItem">
+          <Border x:Name="Bd"
+                  Background="#F0F0F0"
+                  BorderBrush="#CCCCCC"
+                  BorderThickness="1"
+                  CornerRadius="8"
+                  Padding="{TemplateBinding Padding}"
+                  SnapsToDevicePixels="True">
+            <ContentPresenter ContentSource="Header"
+                              HorizontalAlignment="Center"
+                              VerticalAlignment="Center"/>
+          </Border>
+          <ControlTemplate.Triggers>
+            <Trigger Property="IsMouseOver" Value="True">
+              <Setter TargetName="Bd" Property="Background" Value="#E5E5E5"/>
+            </Trigger>
+            <Trigger Property="IsEnabled" Value="False">
+              <Setter Property="Opacity" Value="0.5"/>
+            </Trigger>
+            <Trigger Property="IsSelected" Value="True">
+              <Setter Property="Foreground" Value="White"/>
+              <Setter TargetName="Bd" Property="Background" Value="#0A84FF"/>
+              <Setter TargetName="Bd" Property="BorderBrush" Value="#0A84FF"/>
+              <Setter TargetName="Bd" Property="Effect">
+                <Setter.Value>
+                  <DropShadowEffect BlurRadius="10" ShadowDepth="0" Opacity="0.35"/>
+                </Setter.Value>
+              </Setter>
+            </Trigger>
+          </ControlTemplate.Triggers>
+        </ControlTemplate>
+      </Setter.Value>
+    </Setter>
+  </Style>
 </ResourceDictionary>
 "@
 $lightReader = New-Object System.Xml.XmlNodeReader ([xml]$lightThemeXaml)

--- a/scripts/LAPS-UI.ps1
+++ b/scripts/LAPS-UI.ps1
@@ -363,7 +363,7 @@ Start-Process -FilePath $Exe
     <Style TargetType="TabItem">
       <Setter Property="Foreground" Value="#EEEEEE"/>
       <Setter Property="Padding" Value="14,8"/>
-      <Setter Property="Margin" Value="0,0,8,0"/>
+      <Setter Property="Margin" Value="0"/>
       <Setter Property="Cursor" Value="Hand"/>
       <Setter Property="FocusVisualStyle" Value="{x:Null}"/>
       <Setter Property="Template">
@@ -753,7 +753,7 @@ $lightThemeXaml = @"
   <Style TargetType="TabItem">
     <Setter Property="Foreground" Value="#333333"/>
     <Setter Property="Padding" Value="14,8"/>
-    <Setter Property="Margin" Value="0,0,8,0"/>
+    <Setter Property="Margin" Value="0"/>
     <Setter Property="Cursor" Value="Hand"/>
     <Setter Property="FocusVisualStyle" Value="{x:Null}"/>
     <Setter Property="Template">


### PR DESCRIPTION
## Summary
- add consistent tab item styling for dark and light themes
- widen tab header margin to prevent tab clipping

## Testing
- `powershell -NoLogo -NoProfile -Command "Write-Output 'test'"` *(fails: command not found)*
- `apt-get update` *(fails: repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c1820531008320bfff159b8e97d80c