### PR TITLE
Remove tab item margin to eliminate extra tab spacing

### DIFF
--- a/scripts/LAPS-UI.ps1
+++ b/scripts/LAPS-UI.ps1
@@ -375,7 +375,7 @@ Start-Process -FilePath $Exe
           <!-- Barre d'onglets -->
           <TabPanel x:Name="HeaderPanel"
                     IsItemsHost="True"
-                    Margin="12,12,12,0"
+                    Margin="12,12,20,0"
                     KeyboardNavigation.TabIndex="1"
                     Panel.ZIndex="1"
                     Background="{TemplateBinding Background}"/>
@@ -676,7 +676,7 @@ $lightThemeXaml = @"
 <Style TargetType="TabItem">
   <Setter Property="Foreground" Value="#EEEEEE"/>
   <Setter Property="Padding" Value="14,8"/>
-  <Setter Property="Margin" Value="0,0,8,0"/>
+  <Setter Property="Margin" Value="0"/>
   <Setter Property="Cursor" Value="Hand"/>
   <Setter Property="FocusVisualStyle" Value="{x:Null}"/>
   <Setter Property="Template">


### PR DESCRIPTION
## Summary
- remove fixed right margin from TabItem style
- adjust TabPanel to preserve overall right padding

## Testing
- `pwsh -NoLogo -NoProfile -Command '[System.Management.Automation.PSParser]::Tokenize((Get-Content -Raw scripts/LAPS-UI.ps1), [ref]$null) | Out-Null'` *(failed: command not found)*
- `apt-get update` *(failed: The repository 'http://archive.ubuntu.com/ubuntu noble InRelease' is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c186617f208320ac3ea31d9c13bab1