### PR TITLE
Add margin spacing between tabs in PowerShell UI

### DIFF
--- a/scripts/LAPS-UI.ps1
+++ b/scripts/LAPS-UI.ps1
@@ -353,6 +353,11 @@ Start-Process -FilePath $Exe
   </Window.Resources>
 
   <TabControl Margin="16" Background="#1E1E1E" BorderThickness="0">
+    <TabControl.Resources>
+      <Style TargetType="TabItem">
+        <Setter Property="Margin" Value="0,0,8,0"/>
+      </Style>
+    </TabControl.Resources>
     <TabItem Header="Main">
       <Grid Background="#1E1E1E">
         <Grid.RowDefinitions>


### PR DESCRIPTION
## Summary
- Add TabControl.Resources to define margin style for TabItem, adding spacing between Main and Settings tabs

## Testing
- `pwsh -NoProfile -File scripts/LAPS-UI.ps1` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c7b8925a688320b38ad87b0b0d0e95