### PR TITLE
feat: allow manual update check

### DIFF
--- a/scripts/LAPS-UI.ps1
+++ b/scripts/LAPS-UI.ps1
@@ -243,14 +243,21 @@ Start-Process -FilePath $Exe
 
 function Show-UpdatePrompt {
   param($Info)
+  $script:LastUpdateInfo = $Info
   if ($btnUpdate.Tag) { $btnUpdate.Remove_Click($btnUpdate.Tag) }
   if ($btnIgnore.Tag) { $btnIgnore.Remove_Click($btnIgnore.Tag) }
-  $btnUpdate.Content = "Update to v$($Info.Version)"
+  $btnUpdate.Content = ($t.btnUpdateTo -f $Info.Version)
   $btnUpdate.Visibility = 'Visible'
   $btnIgnore.Visibility = 'Visible'
   $btnUpdate.Tag = { Start-AppUpdate -Info $Info -Window $window }
   $btnUpdate.Add_Click($btnUpdate.Tag)
-  $btnIgnore.Tag = { $script:Prefs.IgnoreVersion = $Info.Version; Save-Prefs; $btnUpdate.Visibility='Collapsed'; $btnIgnore.Visibility='Collapsed' }
+  $btnIgnore.Tag = {
+    $script:Prefs.IgnoreVersion = $Info.Version
+    Save-Prefs
+    $btnUpdate.Visibility='Collapsed'
+    $btnIgnore.Visibility='Collapsed'
+    $lblUpdateStatus.Text = ''
+  }
   $btnIgnore.Add_Click($btnIgnore.Tag)
 }
 # ---------- XAML (Dark) ----------
@@ -584,7 +591,10 @@ function Show-UpdatePrompt {
           <CheckBox x:Name="cbRememberServer" Content="Remember controller/domain"/>
           <StackPanel Orientation="Horizontal">
             <CheckBox x:Name="cbAutoUpdate" Content="Check for updates on launch" IsChecked="True"/>
-            <Button x:Name="btnCheckUpdate" Content="Check now" Margin="8,0,0,0"/>
+            <Button x:Name="btnCheckUpdate" Margin="8,0,0,0" Style="{StaticResource IconButton}">
+              <TextBlock FontFamily="Segoe MDL2 Assets" Text="&#xE72C;"/>
+            </Button>
+            <TextBlock x:Name="lblUpdateStatus" Margin="8,0,0,0" VerticalAlignment="Center" Foreground="{DynamicResource LabelBrush}"/>
           </StackPanel>
           <CheckBox x:Name="cbConfirmCopy" Content="Confirm before copying"/>
         </StackPanel>
@@ -855,6 +865,7 @@ $translations = @{
     lblCompName     = 'Computer name'
     btnGet          = 'Retrieve'
     btnUpdate       = 'Update'
+    btnUpdateTo     = 'Update to v{0}'
     btnIgnore       = 'Ignore'
     cbShow          = 'Show'
     btnCopy         = 'Copy'
@@ -866,8 +877,9 @@ $translations = @{
     cbRememberUser  = 'Remember user'
     cbRememberServer= 'Remember controller/domain'
     cbAutoUpdate    = 'Check for updates on launch'
-    btnCheckUpdate  = 'Check now'
+    btnCheckUpdate_ToolTip  = 'Check now'
     msgNoUpdate     = 'You are up to date.'
+    msgUpdateAvailable = 'Update available: v{0}'
     cbConfirmCopy   = 'Confirm before copying'
     gbAppearance    = 'Appearance'
     lblTheme        = 'Theme'
@@ -898,6 +910,7 @@ $translations = @{
     lblCompName     = "Nom de l'ordinateur"
     btnGet          = 'Récupérer'
     btnUpdate       = 'Mettre à jour'
+    btnUpdateTo     = 'Mettre à jour vers v{0}'
     btnIgnore       = 'Ignorer'
     cbShow          = 'Afficher'
     btnCopy         = 'Copier'
@@ -909,8 +922,9 @@ $translations = @{
     cbRememberUser  = "Mémoriser l'utilisateur"
     cbRememberServer= 'Mémoriser le contrôleur/domaine'
     cbAutoUpdate    = 'Vérifier les mises à jour au lancement'
-    btnCheckUpdate  = 'Vérifier maintenant'
+    btnCheckUpdate_ToolTip  = 'Vérifier maintenant'
     msgNoUpdate     = 'Vous êtes à jour.'
+    msgUpdateAvailable = 'Nouvelle version v{0} disponible.'
     cbConfirmCopy   = 'Confirmer avant de copier'
     gbAppearance    = 'Apparence'
     lblTheme        = 'Thème'
@@ -941,6 +955,7 @@ $translations = @{
     lblCompName     = 'Nombre del equipo'
     btnGet          = 'Obtener'
     btnUpdate       = 'Actualizar'
+    btnUpdateTo     = 'Actualizar a v{0}'
     btnIgnore       = 'Ignorar'
     cbShow          = 'Mostrar'
     btnCopy         = 'Copiar'
@@ -952,8 +967,9 @@ $translations = @{
     cbRememberUser  = 'Recordar usuario'
     cbRememberServer= 'Recordar controlador/dominio'
     cbAutoUpdate    = 'Buscar actualizaciones al iniciar'
-    btnCheckUpdate  = 'Buscar ahora'
+    btnCheckUpdate_ToolTip  = 'Buscar ahora'
     msgNoUpdate     = 'Ya está actualizado.'
+    msgUpdateAvailable = 'Nueva versión v{0} disponible.'
     cbConfirmCopy   = 'Confirmar antes de copiar'
     gbAppearance    = 'Apariencia'
     lblTheme        = 'Tema'
@@ -984,6 +1000,7 @@ $translations = @{
     lblCompName     = 'Nome del computer'
     btnGet          = 'Recupera'
     btnUpdate       = 'Aggiorna'
+    btnUpdateTo     = 'Aggiorna a v{0}'
     btnIgnore       = 'Ignora'
     cbShow          = 'Mostra'
     btnCopy         = 'Copia'
@@ -995,8 +1012,9 @@ $translations = @{
     cbRememberUser  = 'Ricorda utente'
     cbRememberServer= 'Ricorda controller/dominio'
     cbAutoUpdate    = 'Verifica aggiornamenti all avvio'
-    btnCheckUpdate  = 'Verifica ora'
+    btnCheckUpdate_ToolTip  = 'Verifica ora'
     msgNoUpdate     = 'Sei aggiornato.'
+    msgUpdateAvailable = 'Nuova versione v{0} disponibile.'
     cbConfirmCopy   = 'Conferma prima di copiare'
     gbAppearance    = 'Aspetto'
     lblTheme        = 'Tema'
@@ -1027,6 +1045,7 @@ $translations = @{
     lblCompName     = 'Computername'
     btnGet          = 'Abrufen'
     btnUpdate       = 'Aktualisieren'
+    btnUpdateTo     = 'Aktualisieren auf v{0}'
     btnIgnore       = 'Ignorieren'
     cbShow          = 'Anzeigen'
     btnCopy         = 'Kopieren'
@@ -1038,8 +1057,9 @@ $translations = @{
     cbRememberUser  = 'Benutzer speichern'
     cbRememberServer= 'Controller/Domäne speichern'
     cbAutoUpdate    = 'Beim Start nach Updates suchen'
-    btnCheckUpdate  = 'Jetzt prüfen'
+    btnCheckUpdate_ToolTip  = 'Jetzt prüfen'
     msgNoUpdate     = 'Sie sind auf dem neuesten Stand.'
+    msgUpdateAvailable = 'Neue Version v{0} verfügbar.'
     cbConfirmCopy   = 'Vor dem Kopieren bestätigen'
     gbAppearance    = 'Darstellung'
     lblTheme        = 'Design'
@@ -1070,6 +1090,7 @@ $translations = @{
     lblCompName     = 'Nome do computador'
     btnGet          = 'Obter'
     btnUpdate       = 'Atualizar'
+    btnUpdateTo     = 'Atualizar para v{0}'
     btnIgnore       = 'Ignorar'
     cbShow          = 'Mostrar'
     btnCopy         = 'Copiar'
@@ -1081,8 +1102,9 @@ $translations = @{
     cbRememberUser  = 'Lembrar usuário'
     cbRememberServer= 'Lembrar controlador/domínio'
     cbAutoUpdate    = 'Verificar atualizações ao iniciar'
-    btnCheckUpdate  = 'Verificar agora'
+    btnCheckUpdate_ToolTip  = 'Verificar agora'
     msgNoUpdate     = 'Você está atualizado.'
+    msgUpdateAvailable = 'Nova versão v{0} disponível.'
     cbConfirmCopy   = 'Confirmar antes de copiar'
     gbAppearance    = 'Aparência'
     lblTheme        = 'Tema'
@@ -1113,6 +1135,7 @@ $translations = @{
     lblCompName     = '计算机名'
     btnGet          = '获取'
     btnUpdate       = '更新'
+    btnUpdateTo     = '更新到 v{0}'
     btnIgnore       = '忽略'
     cbShow          = '显示'
     btnCopy         = '复制'
@@ -1124,8 +1147,9 @@ $translations = @{
     cbRememberUser  = '记住用户'
     cbRememberServer= '记住控制器/域'
     cbAutoUpdate    = '启动时检查更新'
-    btnCheckUpdate  = '立即检查'
+    btnCheckUpdate_ToolTip  = '立即检查'
     msgNoUpdate     = '已是最新版本。'
+    msgUpdateAvailable = '发现新版本 v{0}。'
     cbConfirmCopy   = '复制前确认'
     gbAppearance    = '外观'
     lblTheme        = '主题'
@@ -1156,6 +1180,7 @@ $translations = @{
     lblCompName     = 'اسم الكمبيوتر'
     btnGet          = 'استرجاع'
     btnUpdate       = 'تحديث'
+    btnUpdateTo     = 'التحديث إلى v{0}'
     btnIgnore       = 'تجاهل'
     cbShow          = 'إظهار'
     btnCopy         = 'نسخ'
@@ -1167,8 +1192,9 @@ $translations = @{
     cbRememberUser  = 'تذكر المستخدم'
     cbRememberServer= 'تذكر المراقب/المجال'
     cbAutoUpdate    = 'التحقق من التحديثات عند التشغيل'
-    btnCheckUpdate  = 'تحقق الآن'
+    btnCheckUpdate_ToolTip  = 'تحقق الآن'
     msgNoUpdate     = 'النظام محدث.'
+    msgUpdateAvailable = 'إصدار جديد v{0} متاح.'
     cbConfirmCopy   = 'التأكيد قبل النسخ'
     gbAppearance    = 'المظهر'
     lblTheme        = 'السمة'
@@ -1190,7 +1216,7 @@ $translations = @{
 function Apply-Language {
   param([string]$Language)
   if (-not $Language -or -not $translations.ContainsKey($Language)) { $Language = 'English' }
-  $t = $translations[$Language]
+  $script:t = $translations[$Language]
   $tabMain.Header       = $t.tabMain
   $tabSettings.Header   = $t.tabSettings
   $gbCreds.Header       = $t.gbCreds
@@ -1215,7 +1241,7 @@ function Apply-Language {
   $cbRememberUser.Content = $t.cbRememberUser
   $cbRememberServer.Content = $t.cbRememberServer
   $cbAutoUpdate.Content = $t.cbAutoUpdate
-  $btnCheckUpdate.Content = $t.btnCheckUpdate
+  $btnCheckUpdate.ToolTip = $t.btnCheckUpdate_ToolTip
   $cbConfirmCopy.Content = $t.cbConfirmCopy
   $gbAppearance.Header  = $t.gbAppearance
   $lblTheme.Text        = $t.lblTheme
@@ -1235,6 +1261,12 @@ function Apply-Language {
     }
   }
   $btnHistory.ToolTip   = $t.btnHistory_ToolTip
+  if ($btnUpdate.Visibility -eq 'Visible' -and $script:LastUpdateInfo) {
+    $btnUpdate.Content = $t.btnUpdateTo -f $script:LastUpdateInfo.Version
+    $lblUpdateStatus.Text = $t.msgUpdateAvailable -f $script:LastUpdateInfo.Version
+  } elseif ($lblUpdateStatus.Text) {
+    $lblUpdateStatus.Text = $t.msgNoUpdate
+  }
 }
 
 # Controls
@@ -1279,6 +1311,7 @@ $cbRememberUser = $window.FindName("cbRememberUser")
 $cbRememberServer = $window.FindName("cbRememberServer")
 $cbAutoUpdate   = $window.FindName("cbAutoUpdate")
 $btnCheckUpdate = $window.FindName("btnCheckUpdate")
+$lblUpdateStatus = $window.FindName("lblUpdateStatus")
 $cbConfirmCopy  = $window.FindName("cbConfirmCopy")
 $cmbTheme       = $window.FindName("cmbTheme")
 $cmbLanguage    = $window.FindName("cmbLanguage")
@@ -1288,6 +1321,7 @@ $btnIgnore     = $window.FindName("btnIgnore")
 # Init
 $cbLdaps.IsChecked = $UseLdaps
 $script:UseLdaps   = [bool]$cbLdaps.IsChecked
+$script:LastUpdateInfo = $null
 $tbClipboardSecs.Text = $script:ClipboardAutoClearSeconds
 $script:CurrentLapsPassword = ""
 $script:DoneTimer = $null
@@ -1393,13 +1427,12 @@ $btnCheckUpdate.Add_Click({
   $info = Check-ForUpdates -CurrentVersion $CurrentVersion
   if ($info) {
     Show-UpdatePrompt $info
+    $lblUpdateStatus.Text = $t.msgUpdateAvailable -f $info.Version
   } else {
-    [System.Windows.MessageBox]::Show(
-      $t.msgNoUpdate,
-      'Update',
-      [System.Windows.MessageBoxButton]::OK,
-      [System.Windows.MessageBoxImage]::Information
-    ) | Out-Null
+    $script:LastUpdateInfo = $null
+    $btnUpdate.Visibility='Collapsed'
+    $btnIgnore.Visibility='Collapsed'
+    $lblUpdateStatus.Text = $t.msgNoUpdate
   }
 })
 $cbConfirmCopy.Add_Checked({ Save-Prefs })
@@ -1572,6 +1605,7 @@ if ($cbAutoUpdate.IsChecked) {
 }
 if ($updateInfo) {
   Show-UpdatePrompt $updateInfo
+  $lblUpdateStatus.Text = $t.msgUpdateAvailable -f $updateInfo.Version
 }
 
 $btnGet.Add_Click({


### PR DESCRIPTION
## Summary
- add "Check now" button in Preferences to manually verify updates
- display update prompt with new helper function
- localize strings for manual update check across supported languages

## Testing
- `pwsh -NoProfile -Command "Write-Host 'testing'"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c7e15b9d68832097d7aaf3f22b46b5