### PR TITLE
feat: disable history button without password

### DIFF
--- a/scripts/LAPS-UI.ps1
+++ b/scripts/LAPS-UI.ps1
@@ -1404,9 +1404,11 @@ function Load-Prefs {
 Load-Prefs
 Apply-Theme $cmbTheme.SelectedItem.Tag
 Apply-Language $(if ($cmbLanguage.SelectedItem) { $cmbLanguage.SelectedItem.Tag } else { 'English' })
-$tbComp.IsEnabled = -not [string]::IsNullOrWhiteSpace($pbPass.Password)
+$tbComp.IsEnabled     = -not [string]::IsNullOrWhiteSpace($pbPass.Password)
+$btnHistory.IsEnabled = -not [string]::IsNullOrWhiteSpace($pbPass.Password)
 $pbPass.Add_PasswordChanged({
-    $tbComp.IsEnabled = -not [string]::IsNullOrWhiteSpace($pbPass.Password)
+    $tbComp.IsEnabled     = -not [string]::IsNullOrWhiteSpace($pbPass.Password)
+    $btnHistory.IsEnabled = -not [string]::IsNullOrWhiteSpace($pbPass.Password)
 })
 $cbRememberUser.Add_Checked({ Save-Prefs })
 $cbRememberUser.Add_Unchecked({ Save-Prefs })


### PR DESCRIPTION
## Summary
- disable history button unless a password is provided

## Testing
- `pwsh -NoLogo -NoProfile -Command "$PSVersionTable.PSVersion"` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `apt-get install -y powershell` *(fails: unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68c7f3855a1c8320a199cf5bc60eaeb0