### PR TITLE
Add lockout reset timer and retry option

### DIFF
--- a/scripts/LAPS-UI.ps1
+++ b/scripts/LAPS-UI.ps1
@@ -1,4 +1,8 @@
-﻿# LAPS-UI.ps1 - WPF Dark, PS 5.1 (STA)
+﻿param(
+  [int]$LockoutResetSeconds = 60
+)
+
+# LAPS-UI.ps1 - WPF Dark, PS 5.1 (STA)
 # LDAP by default, optional LDAPS, modern dark UI, 20s countdown
 # Read-only "LAPS password" field + reliable green "cleared" message
 # Remember user & controller/domain (local JSON), update checker
@@ -7,7 +11,10 @@
 # --- Config ---
 $UseLdaps = $false
 $script:ClipboardAutoClearSeconds = 20
+$script:LockoutResetSeconds = $LockoutResetSeconds
 $CurrentVersion = '1.0.5'
+$script:FailedAuthCount = 0
+$script:LockoutTimer = $null
 
 Add-Type -AssemblyName PresentationFramework, PresentationCore, WindowsBase
 Add-Type -AssemblyName System.DirectoryServices
@@ -511,7 +518,7 @@ function Show-UpdatePrompt {
       <GroupBox Grid.Row="1" Header="Search" x:Name="gbSearch">
         <Grid>
           <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="Auto"/><ColumnDefinition Width="*"/><ColumnDefinition Width="Auto"/><ColumnDefinition Width="Auto"/>
+            <ColumnDefinition Width="Auto"/><ColumnDefinition Width="*"/><ColumnDefinition Width="Auto"/><ColumnDefinition Width="Auto"/><ColumnDefinition Width="Auto"/>
           </Grid.ColumnDefinitions>
           <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
@@ -520,6 +527,7 @@ function Show-UpdatePrompt {
           <TextBox   Grid.Row="0" Grid.Column="1" x:Name="tbComp"/>
           <Button   Grid.Row="0" Grid.Column="2" x:Name="btnHistory" Content="&#xE81C;" FontFamily="Segoe MDL2 Assets" Style="{StaticResource IconButton}" Margin="12,0,0,0" ToolTip="History"/>
           <Button   Grid.Row="0" Grid.Column="3" x:Name="btnGet" Content="Retrieve" Style="{StaticResource AccentButton}" IsDefault="True" Margin="12,0,0,0"/>
+          <Button   Grid.Row="0" Grid.Column="4" x:Name="btnRetry" Content="Retry" Style="{StaticResource AccentButton}" Margin="12,0,0,0" Visibility="Collapsed"/>
           <Popup    x:Name="popCompSuggest" PlacementTarget="{Binding ElementName=tbComp}" Placement="Bottom" StaysOpen="False">
             <Border BorderBrush="#3E3E42" BorderThickness="1" Background="#2D2D2D">
               <ListBox x:Name="lbCompSuggest" MaxHeight="200" Width="{Binding ElementName=tbComp, Path=ActualWidth}" Background="#2D2D2D" Foreground="#EEEEEE"/>
@@ -864,6 +872,7 @@ $translations = @{
     lblController   = 'Controller/Domain'
     lblCompName     = 'Computer name'
     btnGet          = 'Retrieve'
+    btnRetry        = 'Retry'
     btnUpdate       = 'Update'
     btnUpdateTo     = 'Update to v{0}'
     btnIgnore       = 'Ignore'
@@ -909,6 +918,7 @@ $translations = @{
     lblController   = 'Contrôleur/Domaine'
     lblCompName     = "Nom de l'ordinateur"
     btnGet          = 'Récupérer'
+    btnRetry        = 'Réessayer'
     btnUpdate       = 'Mettre à jour'
     btnUpdateTo     = 'Mettre à jour vers v{0}'
     btnIgnore       = 'Ignorer'
@@ -954,6 +964,7 @@ $translations = @{
     lblController   = 'Controlador/Dominio'
     lblCompName     = 'Nombre del equipo'
     btnGet          = 'Obtener'
+    btnRetry        = 'Reintentar'
     btnUpdate       = 'Actualizar'
     btnUpdateTo     = 'Actualizar a v{0}'
     btnIgnore       = 'Ignorar'
@@ -999,6 +1010,7 @@ $translations = @{
     lblController   = 'Controller/Dominio'
     lblCompName     = 'Nome del computer'
     btnGet          = 'Recupera'
+    btnRetry        = 'Riprova'
     btnUpdate       = 'Aggiorna'
     btnUpdateTo     = 'Aggiorna a v{0}'
     btnIgnore       = 'Ignora'
@@ -1044,6 +1056,7 @@ $translations = @{
     lblController   = 'Controller/Domäne'
     lblCompName     = 'Computername'
     btnGet          = 'Abrufen'
+    btnRetry        = 'Erneut versuchen'
     btnUpdate       = 'Aktualisieren'
     btnUpdateTo     = 'Aktualisieren auf v{0}'
     btnIgnore       = 'Ignorieren'
@@ -1089,6 +1102,7 @@ $translations = @{
     lblController   = 'Controlador/Domínio'
     lblCompName     = 'Nome do computador'
     btnGet          = 'Obter'
+    btnRetry        = 'Tentar novamente'
     btnUpdate       = 'Atualizar'
     btnUpdateTo     = 'Atualizar para v{0}'
     btnIgnore       = 'Ignorar'
@@ -1134,6 +1148,7 @@ $translations = @{
     lblController   = '控制器/域'
     lblCompName     = '计算机名'
     btnGet          = '获取'
+    btnRetry        = '重试'
     btnUpdate       = '更新'
     btnUpdateTo     = '更新到 v{0}'
     btnIgnore       = '忽略'
@@ -1179,6 +1194,7 @@ $translations = @{
     lblController   = 'المراقب/المجال'
     lblCompName     = 'اسم الكمبيوتر'
     btnGet          = 'استرجاع'
+    btnRetry        = 'إعادة المحاولة'
     btnUpdate       = 'تحديث'
     btnUpdateTo     = 'التحديث إلى v{0}'
     btnIgnore       = 'تجاهل'
@@ -1229,6 +1245,7 @@ function Apply-Language {
   $lblController.Text   = $t.lblController
   $lblCompName.Text     = $t.lblCompName
   $btnGet.Content       = $t.btnGet
+  $btnRetry.Content     = $t.btnRetry
   $btnUpdate.Content    = $t.btnUpdate
   $btnIgnore.Content    = $t.btnIgnore
   $cbShow.Content       = $t.cbShow
@@ -1295,6 +1312,7 @@ $popCompSuggest = $window.FindName("popCompSuggest")
 $lbCompSuggest  = $window.FindName("lbCompSuggest")
 $btnHistory     = $window.FindName("btnHistory")
 $btnGet         = $window.FindName("btnGet")
+$btnRetry       = $window.FindName("btnRetry")
 $gbDetails      = $window.FindName("gbDetails")
 $txtDetails     = $window.FindName("txtDetails")
 $spExpire       = $window.FindName("spExpire")
@@ -1528,6 +1546,18 @@ function Update-ExpirationIndicator([nullable[DateTime]]$exp) {
   }
 }
 
+function Reset-FailedAuthCount {
+  $script:FailedAuthCount = 0
+  if ($script:LockoutTimer) {
+    $script:LockoutTimer.Stop()
+    $script:LockoutTimer.Dispose()
+    $script:LockoutTimer = $null
+  }
+  if ($btnRetry) {
+    $window.Dispatcher.Invoke({ $btnRetry.Visibility = 'Collapsed' })
+  }
+}
+
 # Show/Hide clear text
 $cbShow.Add_Checked({
   Update-PasswordDisplay $script:CurrentLapsPassword
@@ -1672,15 +1702,25 @@ $btnGet.Add_Click({
       Update-ExpirationIndicator $null
     }
   } catch {
-    $txtDetails.Text = "Error: $($_.Exception.Message)"
+    $msg = $_.Exception.Message
+    $txtDetails.Text = "Error: $msg"
     $gbDetails.Visibility = 'Visible'
     $window.UpdateLayout()
     Update-ExpirationIndicator $null
+    if ($msg -eq 'Too many invalid credential attempts.') {
+      if ($script:LockoutTimer) { $script:LockoutTimer.Stop(); $script:LockoutTimer.Dispose() }
+      $script:LockoutTimer = New-Object System.Timers.Timer ($script:LockoutResetSeconds * 1000)
+      $script:LockoutTimer.AutoReset = $false
+      $script:LockoutTimer.Add_Elapsed({ Reset-FailedAuthCount })
+      $script:LockoutTimer.Start()
+      $btnRetry.Visibility = 'Visible'
+    }
   } finally {
     $window.Cursor = 'Arrow'
     $btnGet.IsEnabled = $true
   }
 })
+$btnRetry.Add_Click({ Reset-FailedAuthCount })
 
 # Enter -> Retrieve
 $tbComp.Add_KeyDown({


### PR DESCRIPTION
## Summary
- add `Reset-FailedAuthCount` helper and configurable `LockoutResetSeconds`
- start timer and show retry button after too many invalid credential attempts
- localize new retry button across supported languages

## Testing
- `pwsh -NoLogo -NoProfile -Command "[System.Management.Automation.Language.Parser]::ParseFile('scripts/LAPS-UI.ps1',[ref]0,[ref]0)"` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed, 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c7fff505708320a3aa84949e2c81dd