### PR TITLE
Disable Retrieve button after max auth attempts

### DIFF
--- a/scripts/LAPS-UI.ps1
+++ b/scripts/LAPS-UI.ps1
@@ -1575,7 +1575,10 @@ function Reset-FailedAuthCount {
     $script:LockoutTimer = $null
   }
   if ($btnRetry) {
-    $window.Dispatcher.Invoke({ $btnRetry.Visibility = 'Collapsed' })
+    $window.Dispatcher.Invoke({
+      $btnRetry.Visibility = 'Collapsed'
+      $btnGet.IsEnabled = $true
+    })
   }
 }
 
@@ -1662,6 +1665,7 @@ if ($updateInfo) {
 }
 
 $btnGet.Add_Click({
+  $lockout = $false
   try {
     $popCompSuggest.IsOpen = $false
     $gbDetails.Visibility = 'Collapsed'
@@ -1747,10 +1751,12 @@ $btnGet.Add_Click({
       $script:LockoutTimer.Add_Elapsed({ Reset-FailedAuthCount })
       $script:LockoutTimer.Start()
       $btnRetry.Visibility = 'Visible'
+      $btnGet.IsEnabled = $false
+      $lockout = $true
     }
   } finally {
     $window.Cursor = 'Arrow'
-    $btnGet.IsEnabled = $true
+    if (-not $lockout) { $btnGet.IsEnabled = $true }
   }
 })
 $btnRetry.Add_Click({ Reset-FailedAuthCount })


### PR DESCRIPTION
## Summary
- Disable the Retrieve button when too many credential attempts have been made
- Re-enable the button once the lockout is reset

## Testing
- `pwsh -NoProfile -Command "[System.Management.Automation.Language.Parser]::ParseInput((Get-Content -Raw 'scripts/LAPS-UI.ps1'), [ref]$null, [ref]$null) | Out-Null"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c803d480148320a793ba379aa2e959